### PR TITLE
updated readme to correct spelling of Eratosthenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@ The suggested order for going through each of the directories is:
 
    1. How can you optimize this program?
    2. Implement [The Sieve of
-      Erathosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes), one
+      Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes), one
       of the oldest algorithms known (ca. 200 BC).


### PR DESCRIPTION
Updated hyperlink text to reflect correct spelling of Eratosthenes.

Prev: "Erathosthenes"
Changed to: "Eratosthenes"
